### PR TITLE
Add engines property to target node 8+

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/unzipit.js",
   "module": "dist/unzipit.module.js",
   "types": "dist/unzipit.d.ts",
+  "engines": {
+    "node": ">=8"
+  },
   "scripts": {
     "build": "npm run build-min && npm run build-ts",
     "build-normal": "rollup -c",


### PR DESCRIPTION
Hi,

It looks like the output of this package includes some un-transpiled async/await which is failing in some older browsers and node versions. Would you mind adding an engines key to your package.json file that specifies the minimum node version?

I've gone with 8+ as that's when async was added.

By adding this property a webpack plugin we use will recognise that it needs to transpile this module for us.

Cheers