### PR TITLE
fix(types): use array type for raw zip entries

### DIFF
--- a/dist/unzipit.d.ts
+++ b/dist/unzipit.d.ts
@@ -5,7 +5,7 @@ export type ZipInfo = {
 
 export type ZipInfoRaw = {
   zip: Zip,
-  entries: [ZipEntry],
+  entries: ZipEntry[],
 };
 
 export type Zip = {


### PR DESCRIPTION
I'm pretty sure this is a mistake? 

The `[Something]` syntax in typescript represents a tuple so `[Something, Something]` is a tuple with 2 values